### PR TITLE
pass params.outdir abs path to finemap modules

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -18,6 +18,7 @@ workflow {
 
   // Define asset files
   chain_file = file("${projectDir}/assets/hg19ToHg38.over.chain")
+  outdir_abspath = file(params.outdir).toAbsolutePath().toString()
 
   // Ensure the folder to store not finemapped loci exists
   file("${params.outdir}/results/not_finemapped_loci").mkdirs()
@@ -130,11 +131,11 @@ workflow {
 
 
 // Run SUSIE_FINEMAPPING process on finemapping_input channel
-  SUSIE_FINEMAPPING(finemapping_input, params.outdir)
+  SUSIE_FINEMAPPING(finemapping_input, outdir_abspath)
 
 
 // Run COJO on failed SUSIE loci (only for specific errors!! Stored in the R script of susie)
-  COJO_AND_FINEMAPPING(SUSIE_FINEMAPPING.out.failed_susie_loci, params.outdir)
+  COJO_AND_FINEMAPPING(SUSIE_FINEMAPPING.out.failed_susie_loci, outdir_abspath)
    
 // Append all to independent SNPs table /// What if the channel is empty?? Can you check and behave accordingly?
   append_ind_snps = COJO_AND_FINEMAPPING.out.ind_snps_table

--- a/modules/local/cojo_and_finemapping/main.nf
+++ b/modules/local/cojo_and_finemapping/main.nf
@@ -7,7 +7,7 @@ process COJO_AND_FINEMAPPING {
 
   input:
     tuple val(meta_study_id), val(meta_finemapping), val(meta_loci), path(gwas_final), path(gwas_final_index), path(susie_error_message)
-    val lauDir
+    val outdir
   
   output:
     path "*_conditioned_loci.pdf", optional:true
@@ -33,7 +33,7 @@ process COJO_AND_FINEMAPPING {
         --p_thresh4 ${meta_finemapping.p_thresh4} \
         --hole ${meta_finemapping.hole} \
         --cs_thresh ${meta_finemapping.cs_thresh} \
-        --results_path ${lauDir} \
+        --results_path ${outdir} \
         --study_id ${meta_study_id.study_id}
     """
 

--- a/modules/local/susie_finemapping/main.nf
+++ b/modules/local/susie_finemapping/main.nf
@@ -6,7 +6,7 @@ process SUSIE_FINEMAPPING {
 
   input:
     tuple val(meta_study_id), val(meta_finemapping), val(meta_loci), path(gwas_final), path(gwas_final_index)
-    val lauDir
+    val outdir
   
   output:
     path "*_susie_finemap.rds", optional:true
@@ -29,7 +29,7 @@ process SUSIE_FINEMAPPING {
         --bfile ${meta_finemapping.bfile} \
         --skip_dentist ${meta_finemapping.skip_dentist} \
         --cs_thresh ${meta_finemapping.cs_thresh} \
-        --results_path ${lauDir} \
+        --results_path ${outdir} \
         --study_id ${meta_study_id.study_id}
     """
 


### PR DESCRIPTION
Closes #28 

As discussed, the path of the output directory is passed to fine-mapping modules. These modules store the string for this path in the output master table.

I've now updated this to reflect the path of the output folder set by the user with `params.outdir`.

At the moment, I'm passing the absolute path of the output directory. Is this OK for downstream processes depending on this master table?