### PR TITLE
fix #59 column selection in munging

### DIFF
--- a/bin/s02_sumstat_munging_and_aligning.R
+++ b/bin/s02_sumstat_munging_and_aligning.R
@@ -4,6 +4,8 @@ suppressMessages(library(optparse))
 suppressMessages(library(readr))
 suppressMessages(library(R.utils))
 suppressMessages(library(data.table))
+suppressMessages(library(stringi))
+
 liftOver <- rtracklayer::liftOver
 import.chain <- rtracklayer::import.chain
 GRanges <- GenomicRanges::GRanges
@@ -178,7 +180,8 @@ dataset.munge_hor=function(sumstats.file
   
   # Select only necessary columns
   columns <- c("phenotype_id","snp_original","CHR","BP","A1","A2","freq","BETA","varbeta","SE","P","MAF","N","type", colname_for_type)
-  dataset <- dataset[, ..columns]
+  valid_cols <- intersect(columns, names(dataset))
+  dataset <- dataset[, ..valid_cols]
   
   if(type == "quant" && "s" %in% names(dataset)){
     dataset$s <- NULL


### PR DESCRIPTION
This PR fixes #59  Flexible column selection in `s02_sumstat_munging_and_aligning.R`

### 🧵 Summary

A patch has been applied to improve robustness in `s02_sumstat_munging_and_aligning.R` by:
1. Avoiding errors when expected columns are missing from input.
2. Loading `stringi` to support flexible input parsing.

This avoids crashes in pipelines where optional columns (like `type`-specific ones) are not guaranteed to be present in all summary statistics files.

---

### ✅ Patch applied
Updated file
```
./bin/s02_sumstat_munging_and_aligning.R b/bin/s02_sumstat_munging_and_aligning.R
```
Added loading of stringi package which is needed for calling `stri_rand_strings`
```
+suppressMessages(library(stringi)) 
```
Applied more flexible selection of columns as not all columns are necessary to be present in sum stats. The solution is not that robust as only subset of columns are free to be present (for example a1_freq)
```
-  dataset <- dataset[, ..columns]
+  valid_cols <- intersect(columns, names(dataset))
+  dataset <- dataset[, ..valid_cols]

```