### PR TITLE
handle error when LD matrix was not calculated due to absense of variants

### DIFF
--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -79,6 +79,13 @@ susie_ld <- prep_susie_ld(
   skip_dentist=opt$skip_dentist
 )
 
+# Check if susie_ld is NULL
+if (is.null(susie_ld)) {
+  susie_error_message <- "prep_susie_ld returned NULL. No SNPs found in the locus or LD matrix could not be computed."
+  write.table(susie_error_message, "failed_susie.txt", row.names = FALSE, col.names = FALSE)
+  quit(save = "no", status = 0, runLast = FALSE)  # Exit the script gracefully
+}
+
 # Filter full GWAS sum stat for locus region
 D_sub <- dataset_aligned[match(rownames(susie_ld),dataset_aligned$SNP),]
 

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -84,7 +84,7 @@ if (is.null(susie_ld)) {
 
   susie_error_message <- "prep_susie_ld returned NULL. No SNPs found in the locus or LD matrix could not be computed."
   
-  L1_finemap <- data.frame(
+  no_variants_in_ld_ref <- data.frame(
     study_id = opt$study_id,
     phenotype_id = opt$phenotype_id,
     chr = opt$chr,
@@ -93,7 +93,7 @@ if (is.null(susie_ld)) {
     not_finemapped_reason = susie_error_message
   )
   write.table(
-    susie_error_message,
+    no_variants_in_ld_ref,
     paste0(random.number, "_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.txt"),
     row.names = FALSE,
     col.names = FALSE

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -81,8 +81,23 @@ susie_ld <- prep_susie_ld(
 
 # Check if susie_ld is NULL
 if (is.null(susie_ld)) {
+
   susie_error_message <- "prep_susie_ld returned NULL. No SNPs found in the locus or LD matrix could not be computed."
-  write.table(susie_error_message, "failed_susie.txt", row.names = FALSE, col.names = FALSE)
+  
+  L1_finemap <- data.frame(
+    study_id = opt$study_id,
+    phenotype_id = opt$phenotype_id,
+    chr = opt$chr,
+    start = opt$start,
+    end = opt$end,
+    not_finemapped_reason = susie_error_message
+  )
+  write.table(
+    susie_error_message,
+    paste0(random.number, "_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.txt"),
+    row.names = FALSE,
+    col.names = FALSE
+  )
   quit(save = "no", status = 0, runLast = FALSE)  # Exit the script gracefully
 }
 

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -92,12 +92,8 @@ if (is.null(susie_ld)) {
     end = opt$end,
     not_finemapped_reason = susie_error_message
   )
-  write.table(
-    no_variants_in_ld_ref,
-    paste0(random.number, "_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.txt"),
-    row.names = FALSE,
-    col.names = FALSE
-  )
+
+  fwrite(no_variants_in_ld_ref, paste0(random.number, "_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.tsv"), sep="\t", na=NA, quote=F)
   quit(save = "no", status = 0, runLast = FALSE)  # Exit the script gracefully
 }
 

--- a/bin/s07_anndata_concat.R
+++ b/bin/s07_anndata_concat.R
@@ -16,24 +16,24 @@ suppressPackageStartupMessages(library(dplyr))
 
 
 
-# # Define command-line options for the script
-# option_list <- list(
-#   make_option(c("-i", "--input"),
-#               type = "character",
-#               default = NULL,
-#               help = "List of .h5ad files",
-#               metavar = "character"),
-#   make_option(c("-o", "--output_file"),
-#               type = "character",
-#               default = NULL,
-#               help = "Name of concatenated .h5ad output file",
-#               metavar = "character")
-# )
-#
-# # Parse the command-line options
-# opt_parser <- OptionParser(usage = "Usage: %prog -i <input> -o <output_file>",
-#                            option_list = option_list)
-# opt <- parse_args(opt_parser)
+# Define command-line options for the script
+option_list <- list(
+  make_option(c("-i", "--input"),
+              type = "character",
+              default = NULL,
+              help = "List of .h5ad files",
+              metavar = "character"),
+  make_option(c("-o", "--output_file"),
+              type = "character",
+              default = NULL,
+              help = "Name of concatenated .h5ad output file",
+              metavar = "character")
+)
+
+# Parse the command-line options
+opt_parser <- OptionParser(usage = "Usage: %prog -i <input> -o <output_file>",
+                           option_list = option_list)
+opt <- parse_args(opt_parser)
 
 
 #' Convert finemap files to AnnData
@@ -360,27 +360,27 @@ finemap2anndata <- function(
 }
 
 # Read list of finemap files
-# input_files <- readLines(opt$input) ### to implement later - files stored in a text file rather than as Rscript arguments
-# #input_files <- strsplit(opt$input, ",")[[1]]
-# finemap_files <- unlist(lapply(input_files, readRDS), recursive = FALSE)
+input_files <- readLines(opt$input) ### to implement later - files stored in a text file rather than as Rscript arguments
+#input_files <- strsplit(opt$input, ",")[[1]]
+finemap_files <- unlist(lapply(input_files, readRDS), recursive = FALSE)
 
-# # Collect study_id and phenotype_id for each credible set
-# study_phenotype_ids <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(study_id, phenotype_id)
+# Collect study_id and phenotype_id for each credible set
+study_phenotype_ids <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(study_id, phenotype_id)
 
-# # Collect chr, start and end for each credible set
-# chr_start_ends <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(chr,start,end)
+# Collect chr, start and end for each credible set
+chr_start_ends <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(chr,start,end)
 
-# # SNP panel
-# snp_panel <- unique(unlist(lapply(finemap_files, function(x) x$finemapping_lABFs$snp)))
+# SNP panel
+snp_panel <- unique(unlist(lapply(finemap_files, function(x) x$finemapping_lABFs$snp)))
 
-# ad <- finemap2anndata(
-#   finemap_files = finemap_files,
-#   preloaded_list = TRUE,
-#   study_id = study_phenotype_ids$study_id,
-#   phenotype_id = study_phenotype_ids$phenotype_id,
-#   chr_start_end_positions = chr_start_ends,
-#   snp_panel = snp_panel,
-#   panel = "HRC"
-# )
+ad <- finemap2anndata(
+  finemap_files = finemap_files,
+  preloaded_list = TRUE,
+  study_id = study_phenotype_ids$study_id,
+  phenotype_id = study_phenotype_ids$phenotype_id,
+  chr_start_end_positions = chr_start_ends,
+  snp_panel = snp_panel,
+  panel = "HRC"
+)
 
-# anndata::write_h5ad(ad, filename = opt$output_file)
+anndata::write_h5ad(ad, filename = opt$output_file)

--- a/bin/s07_anndata_concat.R
+++ b/bin/s07_anndata_concat.R
@@ -16,24 +16,24 @@ suppressPackageStartupMessages(library(dplyr))
 
 
 
-# Define command-line options
-option_list <- list(
-  make_option(c("-i", "--input"),
-              type = "character",
-              default = NULL,
-              help = "List of .h5ad files",
-              metavar = "character"),
-  make_option(c("-o", "--output_file"),
-              type = "character",
-              default = NULL,
-              help = "Name of concatenated .h5ad output file",
-              metavar = "character")
-)
-
-# Parse the command-line options
-opt_parser <- OptionParser(usage = "Usage: %prog -i <input> -o <output_file>",
-                           option_list = option_list)
-opt <- parse_args(opt_parser)
+# # Define command-line options for the script
+# option_list <- list(
+#   make_option(c("-i", "--input"),
+#               type = "character",
+#               default = NULL,
+#               help = "List of .h5ad files",
+#               metavar = "character"),
+#   make_option(c("-o", "--output_file"),
+#               type = "character",
+#               default = NULL,
+#               help = "Name of concatenated .h5ad output file",
+#               metavar = "character")
+# )
+#
+# # Parse the command-line options
+# opt_parser <- OptionParser(usage = "Usage: %prog -i <input> -o <output_file>",
+#                            option_list = option_list)
+# opt <- parse_args(opt_parser)
 
 
 #' Convert finemap files to AnnData
@@ -101,6 +101,15 @@ finemap2anndata <- function(
   
   if(!preloaded_list)
     names(finemap_files) <- finemap_files
+
+  # If there are duplicated names in finemap_files, append suffix "L{index}" to each duplicate
+  if(any(duplicated(names(finemap_files)))) {
+    dup_names <- names(finemap_files)[duplicated(names(finemap_files)) | duplicated(names(finemap_files), fromLast = TRUE)]
+    for(name in unique(dup_names)) {
+      idx <- which(names(finemap_files) == name)
+      names(finemap_files)[idx] <- paste0(name, "::L", seq_along(idx))
+    }
+  }
   
   for (finemap_file in names(finemap_files)) {
     
@@ -141,7 +150,7 @@ finemap2anndata <- function(
       
       new_rows <- data.table(
         snp = finemap$snp,
-        chr = paste0("chr", unique(chr_start_end_positions$chr)),
+        chr = paste0("chr", chr_start_end_positions$chr[which(names(finemap_files)==finemap_file)]),
         pos = finemap$pos
       )
       
@@ -351,27 +360,27 @@ finemap2anndata <- function(
 }
 
 # Read list of finemap files
-input_files <- readLines(opt$input) ### to implement later - files stored in a text file rather than as Rscript arguments
-#input_files <- strsplit(opt$input, ",")[[1]]
-finemap_files <- unlist(lapply(input_files, readRDS), recursive = FALSE)
+# input_files <- readLines(opt$input) ### to implement later - files stored in a text file rather than as Rscript arguments
+# #input_files <- strsplit(opt$input, ",")[[1]]
+# finemap_files <- unlist(lapply(input_files, readRDS), recursive = FALSE)
 
-# Collect study_id and phenotype_id for each credible set
-study_phenotype_ids <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(study_id, phenotype_id)
+# # Collect study_id and phenotype_id for each credible set
+# study_phenotype_ids <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(study_id, phenotype_id)
 
-# Collect chr, start and end for each credible set
-chr_start_ends <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(chr,start,end)
+# # Collect chr, start and end for each credible set
+# chr_start_ends <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(chr,start,end)
 
-# SNP panel
-snp_panel <- unique(unlist(lapply(finemap_files, function(x) x$finemapping_lABFs$snp)))
+# # SNP panel
+# snp_panel <- unique(unlist(lapply(finemap_files, function(x) x$finemapping_lABFs$snp)))
 
-ad <- finemap2anndata(
-  finemap_files = finemap_files,
-  preloaded_list = TRUE,
-  study_id = study_phenotype_ids$study_id,
-  phenotype_id = study_phenotype_ids$phenotype_id,
-  chr_start_end_positions = chr_start_ends,
-  snp_panel = snp_panel,
-  panel = "HRC"
-)
+# ad <- finemap2anndata(
+#   finemap_files = finemap_files,
+#   preloaded_list = TRUE,
+#   study_id = study_phenotype_ids$study_id,
+#   phenotype_id = study_phenotype_ids$phenotype_id,
+#   chr_start_end_positions = chr_start_ends,
+#   snp_panel = snp_panel,
+#   panel = "HRC"
+# )
 
-anndata::write_h5ad(ad, filename = opt$output_file)
+# anndata::write_h5ad(ad, filename = opt$output_file)

--- a/bin/s07_anndata_concat.R
+++ b/bin/s07_anndata_concat.R
@@ -176,7 +176,7 @@ finemap2anndata <- function(
       #message(paste("Error in reading file:", basename(finemap_file), "- Skipping"))
       NULL  # return NULL on error
     })
-    n = which(names(finemap_files) == finemap_file)
+    n = length(names(finemap_files) == finemap_file)
     if(n %% 100 == 0){
       cat("\rFinished", n, "of", length(finemap_files))
     }

--- a/modules/local/susie_finemapping/main.nf
+++ b/modules/local/susie_finemapping/main.nf
@@ -14,7 +14,7 @@ process SUSIE_FINEMAPPING {
     path "*_FINEMAPPED_L1_prior_variance_too_large.tsv", optional:true, emit: finemapped_L1_prior_variance_too_large
     path "*_FINEMAPPED_L1_IBSS_algorithm_did_not_converge.tsv", optional:true, emit: finemapped_L1_IBSS_algorithm_did_not_converge
     path "*_NOT_FINEMAPPED_no_credible_sets_found.tsv", optional:true, emit: not_finemapped_no_credible_sets_found
-    path "*_NOT_FINEMAPPED_no_varaints_from_locus_in_LD_ref.txt", optional:true, emit: not_finemapped_no_variants_from_locus_in_LD_ref
+    path "*_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.tsv", optional:true, emit: not_finemapped_no_variants_from_locus_in_LD_ref
 
   script:
   def args = task.ext.args ?: ''

--- a/modules/local/susie_finemapping/main.nf
+++ b/modules/local/susie_finemapping/main.nf
@@ -14,6 +14,7 @@ process SUSIE_FINEMAPPING {
     path "*_FINEMAPPED_L1_prior_variance_too_large.tsv", optional:true, emit: finemapped_L1_prior_variance_too_large
     path "*_FINEMAPPED_L1_IBSS_algorithm_did_not_converge.tsv", optional:true, emit: finemapped_L1_IBSS_algorithm_did_not_converge
     path "*_NOT_FINEMAPPED_no_credible_sets_found.tsv", optional:true, emit: not_finemapped_no_credible_sets_found
+    path "*_NOT_FINEMAPPED_no_varaints_from_locus_in_LD_ref.txt", optional:true, emit: not_finemapped_no_variants_from_locus_in_LD_ref
 
   script:
   def args = task.ext.args ?: ''

--- a/workflows/finemap/main.nf
+++ b/workflows/finemap/main.nf
@@ -35,6 +35,12 @@ workflow RUN_FINEMAPPING {
       keepHeader: true,
       name: "NOT_FINEMAPPED_no_credible_sets_found.tsv",
       storeDir: "${params.outdir}/results/finemapping_exceptions")
+
+    SUSIE_FINEMAPPING.out.not_finemapped_no_variants_from_locus_in_LD_ref
+    .collectFile(
+      keepHeader: true,
+      name: "NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.tsv",
+      storeDir: "${params.outdir}/results/finemapping_exceptions")
     
     // Append all to coloc_info_master_table
     append_input_coloc = SUSIE_FINEMAPPING.out.susie_info_coloc_table


### PR DESCRIPTION
## 🛠️ Handle case when no variants remain after filtering for LD matrix generation

### Summary

This pull request improves robustness of the SuSiE fine-mapping pipeline by:

- **Checking for failure in LD matrix generation** (`prep_susie_ld`) due to no variants remaining after PLINK filtering.
- **Gracefully skipping such loci** by detecting specific log messages (`"No variants remaining after main filters"`) from PLINK.
- **Returning `NULL`** in such cases to prevent downstream errors and unnecessary computation.
- **Adding a check in `s04_susie_finemapping.R`** to:
  - Detect if `susie_ld` is `NULL`
  - Log an informative message to `failed_susie.txt`
  - Exit the script with status 0 (clean exit).

### Motivation

Without this check, the pipeline crashes when PLINK returns no variants for a locus (e.g. after applying MAF filters), which can happen in real datasets with sparse signals or poor variant overlap.

### Files Modified

- `bin/funs_locus_breaker_cojo_finemap_all_at_once.R`: Add conditional logic to handle empty variant set after PLINK filtering.
- `bin/s04_susie_finemapping.R`: Add `NULL` check for `susie_ld` and exit gracefully.

```