### PR TITLE
Fix chromosome name formatting

### DIFF
--- a/bin/s07_anndata_concat.R
+++ b/bin/s07_anndata_concat.R
@@ -150,7 +150,7 @@ finemap2anndata <- function(
       
       new_rows <- data.table(
         snp = finemap$snp,
-        chr = paste0("chr", chr_start_end_positions$chr[which(names(finemap_files)==finemap_file)]),
+        chr = chr_start_end_positions$chr[which(names(finemap_files)==finemap_file)],
         pos = finemap$pos
       )
       
@@ -369,6 +369,8 @@ study_phenotype_ids <- rbindlist(lapply(finemap_files, function(x) x$metadata)) 
 
 # Collect chr, start and end for each credible set
 chr_start_ends <- rbindlist(lapply(finemap_files, function(x) x$metadata)) %>% dplyr::select(chr,start,end)
+
+chr_start_ends$chr <- paste0("chr", chr_start_ends$chr) # add "chr" prefix to chromosome names
 
 # SNP panel
 snp_panel <- unique(unlist(lapply(finemap_files, function(x) x$finemapping_lABFs$snp)))


### PR DESCRIPTION
## 🧬 Harmonize chromosome naming in AnnData

### Summary

This PR fixes an inconsistency in chromosome naming between `anndata$obs$chr` and `anndata$var$chr`.

### Problem

Previously, the two annotations used different formats for chromosome labels:
- `anndata$obs$chr` stored values like `"1"`, `"2"`, etc. (or "chr1"`, `"chr2")
- `anndata$var$chr` stored values with the `additional "chr"` prefix, such as `"chr1"`, `"chr2"`, etc. (or "chrchr1"`, `"chrchr2")

### Fix

This update ensures consistent formatting across both `obs$chr` and `var$chr` fields to avoid downstream issues during filtering, matching, or plotting.
```