### PR TITLE
Fix label in PROCESS_BFILE to use defined process_single profile

### DIFF
--- a/modules/local/process_bfile/main.nf
+++ b/modules/local/process_bfile/main.nf
@@ -1,6 +1,6 @@
 process PROCESS_BFILE {
     tag "${bfile_dataset[0].baseName}"
-    label "process_small"
+    label "process_single"
 
     publishDir "${params.outdir}/processed_bfiles", mode: params.publish_dir_mode,  pattern: "${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.{bed,bim,fam}"
 


### PR DESCRIPTION
This PR updates the label used in the PROCESS_BFILE process in modules/local/process_bfile/main.nf, changing it from "process_small" to "process_single".
The previous label was not defined in the config, which could cause execution errors or fallback to default resources.

This change ensures the process runs under the appropriate profile with the intended resource configuration.

No other logic has been modified.