### PR TITLE
Allow the user to specify chromosomes intervals for analysis

### DIFF
--- a/bin/s02_sumstat_munging_and_aligning.R
+++ b/bin/s02_sumstat_munging_and_aligning.R
@@ -55,6 +55,7 @@ IRanges <- IRanges::IRanges
 dataset.munge_hor=function(sumstats.file
                            ,snp.lab="SNP"
                            ,chr.lab="CHR"
+                           ,accepted.chr="1-22"
                            ,pos.lab="BP"
                            ,a1.lab="A1"
                            ,a0.lab="A2"
@@ -67,7 +68,22 @@ dataset.munge_hor=function(sumstats.file
                            ,sdY=NULL
                            ,s=NULL
                            ){
-  
+
+  # Convert the accepted.chr string like 1-22 or 1-5,6-9,12 in a vector of numbers
+  accepted.chr.vec = unlist(lapply(strsplit(accepted.chr, ","), function(x) {
+    as.numeric(unlist(lapply(strsplit(x, "-"), function(y) {
+      if(length(y) == 2) {
+        return(seq(as.numeric(y[1]), as.numeric(y[2])))
+      } else {
+        return(as.numeric(y))
+      }
+    })))
+  }))
+  # Check there are no NA in accepted.chr.vec which mean we failed to convert properly
+  if(any(is.na(accepted.chr.vec))) {
+    stop("Failed to convert accepted.chr to numeric values. The string was: ", accepted.chr)
+  }
+
   # Load sumstat
   dataset = gwas
   if(is.character(sumstats.file)){
@@ -100,8 +116,16 @@ dataset.munge_hor=function(sumstats.file
   
   if(!is.null(chr.lab) & chr.lab %in% names(dataset)){
     names(dataset)[names(dataset)==chr.lab]="CHR"
-    dataset[ , CHR := as.numeric(dataset$CHR)] ### set as numeric, can't merge columns of different classes
-    dataset <- dataset[CHR %in% c(1:22)]
+    # Convert to string to be sure we can process
+    dataset[ , CHR := as.character(CHR)]
+    # First, remove chr prefix if present at the beginning of CHR column (case insensitive)
+    dataset[ , CHR := gsub("^[Cc][Hh][Rr]", "", CHR)]
+    # Second, convert X to 23 and Y to 24
+    dataset[ , CHR := gsub("X", "23", CHR)]
+    dataset[ , CHR := gsub("Y", "24", CHR)]
+    # Finally, make CHR values numeric to be compatible with plink encoding
+    dataset[ , CHR := as.numeric(CHR)] ### set as numeric, can't merge columns of different classes
+    dataset <- dataset[CHR %in% accepted.chr.vec]
   }else{
     stop("chr.lab has not been defined or the column is missing") ### Can be as well retrieved from LD reference bfiles??
   }
@@ -486,6 +510,7 @@ option_list <- list(
   make_option("--is_molQTL", default=NULL, type="logical", help="Whether the summary statistics provided are for eQTLs, ATAC, ChipSeq etc. data"),
   make_option("--key", default=NULL, help="If GWAS is from a molQTL, name of column reporting the trait/phenoptype"),
   make_option("--chr_lab", default="CHROM", help="Name of chromosome column in GWAS summary statistics"),
+  make_option("--accepted_chr", default="1-22", help="Accepted chromosome ranges in GWAS summary statistics"),
   make_option("--pos_lab", default="GENPOS", help="Name of genetic position column in GWAS summary statistics"),
   make_option("--rsid_lab", default="ID", help="Name of rsid column"),  
   make_option("--a1_lab", default="ALLELE1", help="Name of effect allele column"),  
@@ -562,6 +587,7 @@ dataset_munged <- dataset.munge_hor(
   gwas
   ,snp.lab = opt$rsid_lab
   ,chr.lab = opt$chr_lab
+  ,accepted.chr = opt$accepted_chr
   ,pos.lab = opt$pos_lab
   ,a1.lab = opt$a1_lab
   ,a0.lab = opt$a0_lab

--- a/lib/utils.nf
+++ b/lib/utils.nf
@@ -1,0 +1,31 @@
+// Check and parse numeric intervals
+def parseIntervals(intervalString) {
+    if (!intervalString?.trim()) {
+        error "Interval string cannot be null or empty"
+    }
+    
+    def clean = intervalString.replaceAll(/\s+/, '')
+    
+    // Validate format
+    if (!(clean ==~ /^[\d,-]+$/ || clean ==~ /.*[--,,].*/ || clean ==~ /^[-,].*/ || clean ==~ /.*[-,]$/ || clean ==~ /.*[-,][-,].*/ )) {
+        error "Invalid interval format: '${intervalString}'"
+    }
+    
+    def result = []
+    
+    try {
+        clean.split(',').each { part ->
+            if (part.contains('-')) {
+                def (start, end) = part.split('-').collect { it.toInteger() }
+                if (start > end) error "Invalid range: ${start}-${end}"
+                (start..end).each { if (!result.contains(it)) result << it }
+            } else {
+                def num = part.toInteger()
+                if (!result.contains(num)) result << num
+            }
+        }
+        return result.sort()
+    } catch (NumberFormatException e) {
+        error "Invalid number in: '${intervalString}'"
+    }
+}

--- a/main.nf
+++ b/main.nf
@@ -6,11 +6,16 @@ include { PROCESS_BFILE } from "./modules/local/process_bfile"
 include { GET_STUDY_FROM_ANNDATA } from "./modules/local/get_study_from_anndata"
 include { completionSummary } from "./modules/local/pipeline_utils"
 include { validateParameters; paramsSummaryLog; samplesheetToList } from 'plugin/nf-schema'
+include { parseIntervals } from './lib/utils'
 
 workflow {
 	// validate and log pipeline parameters
 	validateParameters()
 	log.info paramsSummaryLog(workflow)
+
+	// additional validation for chromosome intervals
+	def parsed_intervals = parseIntervals(params.chromosomes)
+	log.info "Parsed chromosome intervals: ${parsed_intervals}"
 
 	// Define asset files
   	chain_file = file("${projectDir}/assets/hg19ToHg38.over.chain")

--- a/main.nf
+++ b/main.nf
@@ -111,6 +111,7 @@ workflow {
 				"run_liftover": params.run_liftover ? "T" : "F",
 				"key": row.key,
 				"chr_lab": row.chr_lab,
+				"accepted_chr": params.chromosomes,
 				"pos_lab": row.pos_lab,
 				"rsid_lab": row.rsid_lab,
 				"a1_lab": row.a1_lab,

--- a/modules/local/mung_and_locus_breaker/main.nf
+++ b/modules/local/mung_and_locus_breaker/main.nf
@@ -29,6 +29,7 @@ process MUNG_AND_LOCUS_BREAKER {
         --key ${meta_parameters.key} \
         --rsid_lab ${meta_parameters.rsid_lab} \
         --chr_lab ${meta_parameters.chr_lab} \
+        --accepted_chr ${meta_parameters.accepted_chr} \
         --pos_lab ${meta_parameters.pos_lab} \
         --a1_lab ${meta_parameters.a1_lab} \
         --a0_lab ${meta_parameters.a0_lab} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,8 @@ params {
     outdir = "flanders_output"
     
     // -- MUNGING and FINEMAPPING SETTINGS --
-    run_liftover = true //perform liftover from GRCh37 to GRCh38 when needed
+    chromosomes = "1-22" // a string setting chromosomes to include in munging and finemapping. Intervals string can be like 1-22 or 1,6,3 or 1-6,7-10 
+    run_liftover = true // perform liftover from GRCh37 to GRCh38 when needed
     large_locus_size = 2000000 // Maximum locus size allowed to finemap
     susie_max_iter = 400 // Maximum number of IBSS iterations to perform, see https://stephenslab.github.io/susieR/reference/susie.html
     publish_susie = false // Whether to publish the susie finemap .rds intermediate files

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -59,6 +59,11 @@
           "description": "An ID for the finemapping results, will be used as prefix in the h5ad finemapping output",
           "default": "finemap_run"
         },
+        "chromosomes": {
+          "type": "string",
+          "description": "A string setting chromosomes to include in munging and finemapping. Intervals string can be like 1-22 or 1,6,3 or 1-6,7-10",
+          "default": "1-22"
+        },
         "run_liftover": {
           "type": "boolean",
           "default": true,
@@ -87,7 +92,12 @@
           "description": "Whether to publish the susie finemap .rds intermediate files"
         }
       },
-      "required": ["finemap_id", "large_locus_size", "susie_max_iter"],
+      "required": [
+        "finemap_id",
+        "chromosomes",
+        "large_locus_size",
+        "susie_max_iter"
+      ],
       "fa_icon": "fas fa-bezier-curve"
     },
     "colocalization": {


### PR DESCRIPTION
Closes #86.

The user can now specify desired chromosome intervals for the analysis. This allows the user to analyze chrX and chrY if needed.

Only chromosomes 1-22, X, and Y are accepted.

## Summary of changes

- new parameter: `chromosomes` with default "1-22". This accepts an interval string like 1-22 or 1,3,4 or 1-6,9-12 etc. (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/nextflow.config#L14)
- updated the validatio schema accordingly (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/nextflow_schema.json#L62-L66)
- updated the munging module to take in the new parameter (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/modules/local/mung_and_locus_breaker/main.nf#L32)
- updated the munging R script
  1. the interval string is converted to a numeric vector, or the script fails if it can not (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/bin/s02_sumstat_munging_and_aligning.R#L73-L85)
  2. the value in CHR column are converted to string, the chr/CHR/Chr prefix is eventually removed and the values are then converted to numeric (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/bin/s02_sumstat_munging_and_aligning.R#L120-L127)
  3. the table is subset to CHR values in the accepted numeric vector (https://github.com/Biostatistics-Unit-HT/Flanders/blob/0fdf3df05d82fa9f5adc154f3c9ff075918ee71b/bin/s02_sumstat_munging_and_aligning.R#L128)