### PR TITLE
Fixing bim_to_clean that is not found when grch37

### DIFF
--- a/bin/s01_alpha_sort_alleles_snpid.R
+++ b/bin/s01_alpha_sort_alleles_snpid.R
@@ -83,7 +83,7 @@ if(as.numeric(opt$grch)==37 && as.logical(opt$run_liftover)){
   
   bim_to_clean <- hg19ToHg38_liftover(bim)
   
-} else if(as.numeric(opt$grch)==38){
+} else {
 
   bim_to_clean <- bim
 


### PR DESCRIPTION
I realised that when both the bim and gwas are grch37 and the liftover is false the program gives error. The reason are quite obvious looking at the commit