### PR TITLE
Latest fixes inspired by UKBB Cardinal

### DIFF
--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -193,8 +193,8 @@ for (i in 1:nrow(loci_df)) {
 # If successfull, pass to QC
 if (!is.null(fitted_rss) && !is.null(fitted_rss$sets$cs)) {
   
-  # Perform QC only for loci fine-mapped with L=10 (or whatever number was set)
-  if (length(fitted_rss$KL)==L) {
+  # Perform QC only for loci fine-mapped with L=10 (or whatever number was set) or, if N SNPs < L, with L=N SNPs in the locus
+  if (length(fitted_rss$KL) == L | length(fitted_rss$KL) == nrow(D_sub)){
 
   ### Post susie QC od credible sets
   #  fitted_rss_cleaned <- flanders::susie.cs.ht( ### THIS IS TEMPORARY UNTIL UPDATE OF THE GITHUB FLANDERS R REPO

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -163,7 +163,7 @@ for (i in 1:nrow(loci_df)) {
     )
 
     fwrite(no_variants_in_ld_ref, paste0(random.number, "_NOT_FINEMAPPED_no_variants_from_locus_in_LD_ref.tsv"), sep="\t", na=NA, quote=F)
-    quit(save = "no", status = 0, runLast = FALSE)  # Exit the script gracefully
+    next # skip this iteration and continue with the next one
   }
 
   # Filter full GWAS sum stat for locus region


### PR DESCRIPTION
Small (but crucial!) fixes to Flanders brought up by UKBB Cardinal fine-mapping run:

1. In [s04_susie_finemapping.R](https://github.com/Biostatistics-Unit-HT/Flanders/blob/main/bin/s04_susie_finemapping.R), `length(KL)` is either checked against `L=10` or `1`. But in case of a locus with less than 10 SNPs, KL will be niether. Adjust with `length(fitted_rss$KL) == L | length(fitted_rss$KL)== nrow(D_sub)`

2. in [s04_susie_finemapping](https://github.com/Biostatistics-Unit-HT/Flanders/blob/main/bin/s04_susie_finemapping.R), `quit(save = "no", status = 0, runLast = FALSE)  # Exit the script gracefully` was replaced by `next` to skip this iteration and continue with the next one, rather than breaking the loop and exiting the script