### PR TITLE
Mantain SNPs order in .bim after liftover, to avoid mismatches with .bed

### DIFF
--- a/bin/s01_alpha_sort_alleles_snpid.R
+++ b/bin/s01_alpha_sort_alleles_snpid.R
@@ -44,7 +44,15 @@ hg19ToHg38_liftover <- function(
   setnames(dataset_ranges38_df, "end", "BP")
   dataset_ranges38_df <- dataset_ranges38_df[, .(BP, snp_original)]
   
-  dataset_lifted <- merge(dataset_munged[, !"BP"], dataset_ranges38_df, by = "snp_original", all = FALSE)
+#  dataset_lifted <- merge(dataset_munged[, !"BP"], dataset_ranges38_df, by = "snp_original", all = FALSE)
+
+# New merge which keeps original file order - CRUCIAL TO MANTAIN ALIGNMENT WITH .BED!!
+  dataset_lifted <- dataset_ranges38_df[
+    dataset_munged[, !"BP"],
+    on = "snp_original",
+    nomatch = 0
+  ]
+
   return(dataset_lifted)
 }
 
@@ -88,6 +96,7 @@ if(as.numeric(opt$grch)==37 && as.logical(opt$run_liftover)){
   bim_to_clean <- bim
 
 }
+
 # Remove rows with duplicated SNP by CHR POS
 # This get rid of multi-allelic variants and any other odd situations
 bim_cleaned <- bim_to_clean[!(duplicated(bim_to_clean[, .(CHR, BP)]) | duplicated(bim_to_clean[, .(CHR, BP)], fromLast=T))]


### PR DESCRIPTION
During liftover of plink bfiles in [s01_alpha_sort_alleles_snpid.R](https://github.com/Biostatistics-Unit-HT/Flanders/blob/main/bin/s01_alpha_sort_alleles_snpid.R), we perform a merge between the old and new .bim (to add the lifted positions), but the merge changes the order of the SNPs. But in the .bed, the SNPs order stays the same, leading thus to mismatch in LD and allele frequency.

This PR introduce a small but crucial fix to mantain the original SNP order during the whole liftover process. Please note that liftover per se is performed correctly (GRCh 37 position are lifted to the correct corresponding GRCh 38 position), the issue is caused by the "shuffling" of SNPs order in the .bim file.

Here below I'm pasting BEFORE and AFTER fix plots, showing correlation of GWAS z-scores and z-scores expected based on LD

<img width="2400" height="1062" alt="image" src="https://github.com/user-attachments/assets/8dc2cd9d-cf25-41ad-9ea1-3225fbd3b1d3" />

<img width="2400" height="1062" alt="image" src="https://github.com/user-attachments/assets/15c86546-b96f-4335-8f31-fbef570b9493" />

