### PR TITLE
Add support for PLINK2 pgen/pvar/psam input across pipeline

### DIFF
--- a/bin/funs_locus_breaker_cojo_finemap_all_at_once.R
+++ b/bin/funs_locus_breaker_cojo_finemap_all_at_once.R
@@ -39,7 +39,8 @@ run_dentist <- function(D=dataset_aligned
   write(locus_only.snp, ncol=1,file=paste0(random.number,"_locus_only.snp.list"))
   
   # Prepare subset of plink LD files    
-  exit_status = system(paste0("plink2 --bfile ", bfile," --extract ",random.number,"_locus_only.snp.list --maf ", maf.thresh, " --make-bed --out ", random.number))
+  plink_input <- get_plink2_input_flag(bfile)
+  exit_status = system(paste0("plink2 ", plink_input," --extract ",random.number,"_locus_only.snp.list --maf ", maf.thresh, " --make-bed --out ", random.number))
   
   # Raise an error if the external command fails
   if (exit_status != 0) {
@@ -82,6 +83,16 @@ run_dentist <- function(D=dataset_aligned
 
 
 
+#### get_plink2_input_flag ####
+# Auto-detect genotype format (pgen/psam/pvar vs bed/bim/fam) and return the correct plink2 flag
+get_plink2_input_flag <- function(prefix) {
+  if (file.exists(paste0(prefix, ".pgen"))) {
+    return(paste0("--pfile ", prefix))
+  } else {
+    return(paste0("--bfile ", prefix))
+  }
+}
+
 #### prep_susie_ld ####
 # Prepare LD matrix for SUSIE
 prep_susie_ld <- function(
@@ -104,7 +115,8 @@ prep_susie_ld <- function(
   }
   
   ### --export A include-alt --> creates a new fileset, after sample/variant filters have been applied - A: sample-major additive (0/1/2) coding, suitable for loading from R 
-  exit_status = system(paste0("plink2 --bfile ", bfile, " --extract ", random.number, "_locus_only.snp.list --maf ", maf.thresh, " --export A include-alt --out ", random.number))
+  plink_input <- get_plink2_input_flag(bfile)
+  exit_status = system(paste0("plink2 ", plink_input, " --extract ", random.number, "_locus_only.snp.list --maf ", maf.thresh, " --export A include-alt --out ", random.number))
   
   # Check if the command failed
   if (exit_status != 0) {

--- a/bin/funs_locus_breaker_cojo_finemap_all_at_once.R
+++ b/bin/funs_locus_breaker_cojo_finemap_all_at_once.R
@@ -83,27 +83,19 @@ run_dentist <- function(D=dataset_aligned
 
 
 
-#### get_plink2_input_flag ####
-# Auto-detect genotype format (pgen/psam/pvar vs bed/bim/fam) and return the correct plink2 flag
-get_plink2_input_flag <- function(prefix) {
-  if (file.exists(paste0(prefix, ".pgen"))) {
-    return(paste0("--pfile ", prefix))
-  } else {
-    return(paste0("--bfile ", prefix))
-  }
-}
 
 #### prep_susie_ld ####
 # Prepare LD matrix for SUSIE
 prep_susie_ld <- function(
     D=dataset_aligned,
-    locus_chr=opt$chr,
-    locus_start=opt$start,
-    locus_end=opt$end,
-    bfile=opt$bfile,
-    maf.thresh=opt$maf,
+    locus_chr=chr,
+    locus_start=start,
+    locus_end=end,
+    bfile=bfile,
+    bfile_type=bfile_type,
+    maf.thresh=maf,
     random.number="ZUlGe4EnYqGkubYrApHu",
-    skip_dentist=opt$skip_dentist
+    skip_dentist=skip_dentist
 ){
   
   if (skip_dentist == TRUE){
@@ -115,9 +107,12 @@ prep_susie_ld <- function(
   }
   
   ### --export A include-alt --> creates a new fileset, after sample/variant filters have been applied - A: sample-major additive (0/1/2) coding, suitable for loading from R 
-  plink_input <- get_plink2_input_flag(bfile)
-  exit_status = system(paste0("plink2 ", plink_input, " --extract ", random.number, "_locus_only.snp.list --maf ", maf.thresh, " --export A include-alt --out ", random.number))
-  
+  if(bfile_type=="plink1"){
+    exit_status = system(paste0("plink2 --bfile ", bfile," --extract ", random.number, "_locus_only.snp.list --maf ", maf.thresh, " --export A include-alt --out ", random.number))
+  } else if(bfile_type=="plink2"){
+    exit_status = system(paste0("plink2 --pfile ", bfile," --extract ", random.number, "_locus_only.snp.list --maf ", maf.thresh, " --export A include-alt --out ", random.number))
+  }
+
   # Check if the command failed
   if (exit_status != 0) {
     # Check if the error is due to no variants remaining

--- a/bin/s01_alpha_sort_alleles_snpid.R
+++ b/bin/s01_alpha_sort_alleles_snpid.R
@@ -58,16 +58,33 @@ hg19ToHg38_liftover <- function(
 
 # Get arguments specified in the sbatch
 option_list <- list(
-    make_option("--bfile", default=NULL, help="Path and prefix name of custom LD bfiles (PLINK format .bed .bim .fam)"),
+    make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
     make_option("--run_liftover", type = "logical", default=TRUE, help="Perform liftover to GRCh38?"),
     make_option("--grch", default=NULL, help="Genome reference build of GWAS sum stats")
 );
 opt_parser = OptionParser(option_list=option_list);
 opt = parse_args(opt_parser);
 
-## Change snpids
-bim <- fread(paste0(opt$bfile, ".bim"))
-names(bim) <- c("CHR","snp_original","V3", "BP","V5","V6")
+# Detect input format
+is_pgen <- file.exists(paste0(opt$bfile, ".pgen"))
+
+## Read variant info
+if (is_pgen) {
+  # .pvar has header lines starting with ## and a #CHROM header line
+  pvar <- fread(paste0(opt$bfile, ".pvar"), skip = "#CHROM")
+  names(pvar)[1] <- "CHR"
+  bim <- data.table(
+    CHR = pvar$CHR,
+    snp_original = pvar$ID,
+    V3 = 0,
+    BP = pvar$POS,
+    V5 = pvar$REF,
+    V6 = pvar$ALT
+  )
+} else {
+  bim <- fread(paste0(opt$bfile, ".bim"))
+  names(bim) <- c("CHR","snp_original","V3", "BP","V5","V6")
+}
 
 # Make a standardized snp id as CHR:BP:V5:V6 and save this as reference for downstream operations
 bim <- bim |>
@@ -79,6 +96,12 @@ fwrite(
   paste0(opt$bfile, ".standard_snpid.bim"),
   quote=F, na=NA, sep="\t", col.names = F
 )
+
+# If pgen format, also write a .pvar with updated IDs for plink2
+if (is_pgen) {
+  pvar_out <- data.table(`#CHROM` = bim$CHR, POS = bim$BP, ID = bim$snp_original, REF = bim$V5, ALT = bim$V6)
+  fwrite(pvar_out, paste0(opt$bfile, ".standard_snpid.pvar"), quote=F, na=NA, sep="\t")
+}
 
 # Remove SNPs where SNP ID is duplicated since this can mess up liftOver and other operations downstream
 if (sum(duplicated(bim$snp_original)) > 0 ) {
@@ -101,12 +124,16 @@ if(as.numeric(opt$grch)==37 && as.logical(opt$run_liftover)){
 # This get rid of multi-allelic variants and any other odd situations
 bim_cleaned <- bim_to_clean[!(duplicated(bim_to_clean[, .(CHR, BP)]) | duplicated(bim_to_clean[, .(CHR, BP)], fromLast=T))]
 
-# Save list of SNP ids to extract from .bed
+# Save list of SNP ids to extract
 extract_file <- paste0(opt$bfile, "_snps_to_extract.txt")
 fwrite(list(bim_cleaned |> dplyr::pull(snp_original) |> unique()), extract_file, col.names=F, quote=F)
 
-# Extract list of SNPs from .bim (to match it with .bed!)
-exit_status = system(paste0("plink2 --bed ", opt$bfile, ".bed --fam ", opt$bfile, ".fam --bim ", opt$bfile, ".standard_snpid.bim --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
+# Extract list of SNPs and output as bed/bim/fam
+if (is_pgen) {
+  exit_status = system(paste0("plink2 --pgen ", opt$bfile, ".pgen --psam ", opt$bfile, ".psam --pvar ", opt$bfile, ".standard_snpid.pvar --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
+} else {
+  exit_status = system(paste0("plink2 --bed ", opt$bfile, ".bed --fam ", opt$bfile, ".fam --bim ", opt$bfile, ".standard_snpid.bim --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
+}
   
 # Raise an error if the external command fails
 if (exit_status != 0) {

--- a/bin/s01_alpha_sort_alleles_snpid.R
+++ b/bin/s01_alpha_sort_alleles_snpid.R
@@ -59,6 +59,7 @@ hg19ToHg38_liftover <- function(
 # Get arguments specified in the sbatch
 option_list <- list(
     make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
+    make_option("--file-type", default = NULL, help = "Input file type: plink1 or plink2"),
     make_option("--run_liftover", type = "logical", default=TRUE, help="Perform liftover to GRCh38?"),
     make_option("--grch", default=NULL, help="Genome reference build of GWAS sum stats")
 );
@@ -91,17 +92,21 @@ bim <- bim |>
   dplyr::mutate(
     snp_original = paste0(CHR, ":", BP, ":", V5, ":", V6)
   )
-fwrite(
-  bim,
-  paste0(opt$bfile, ".standard_snpid.bim"),
-  quote=F, na=NA, sep="\t", col.names = F
-)
 
-# If pgen format, also write a .pvar with updated IDs for plink2
 if (is_pgen) {
-  pvar_out <- data.table(`#CHROM` = bim$CHR, POS = bim$BP, ID = bim$snp_original, REF = bim$V5, ALT = bim$V6)
-  fwrite(pvar_out, paste0(opt$bfile, ".standard_snpid.pvar"), quote=F, na=NA, sep="\t")
+    pvar_standard <- data.table(
+        `#CHROM` = bim$CHR,
+        POS = bim$BP,
+        ID = bim$snp_original,
+        REF = bim$V5,
+        ALT = bim$V6
+    )
+    fwrite(pvar_standard, paste0(opt$bfile, ".standard_snpid.pvar"), quote = FALSE, na = NA, sep = "\t")
+} else {
+    fwrite(bim, paste0(opt$bfile, ".standard_snpid.bim"), quote = FALSE, na = NA, sep = "\t", col.names = FALSE)
 }
+
+
 
 # Remove SNPs where SNP ID is duplicated since this can mess up liftOver and other operations downstream
 if (sum(duplicated(bim$snp_original)) > 0 ) {
@@ -111,13 +116,9 @@ if (sum(duplicated(bim$snp_original)) > 0 ) {
 
 # If necessary, lift to build 38
 if(as.numeric(opt$grch)==37 && as.logical(opt$run_liftover)){
-  
   bim_to_clean <- hg19ToHg38_liftover(bim)
-  
 } else {
-
   bim_to_clean <- bim
-
 }
 
 # Remove rows with duplicated SNP by CHR POS
@@ -128,9 +129,9 @@ bim_cleaned <- bim_to_clean[!(duplicated(bim_to_clean[, .(CHR, BP)]) | duplicate
 extract_file <- paste0(opt$bfile, "_snps_to_extract.txt")
 fwrite(list(bim_cleaned |> dplyr::pull(snp_original) |> unique()), extract_file, col.names=F, quote=F)
 
-# Extract list of SNPs and output as bed/bim/fam
+# Extract list of SNPs and output as bed/bim/fam or pgen/pvar/psam
 if (is_pgen) {
-  exit_status = system(paste0("plink2 --pgen ", opt$bfile, ".pgen --psam ", opt$bfile, ".psam --pvar ", opt$bfile, ".standard_snpid.pvar --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
+  exit_status = system(paste0("plink2 --pgen ", opt$bfile, ".pgen --psam ", opt$bfile, ".psam --pvar ", opt$bfile, ".standard_snpid.pvar --extract ", extract_file, " --make-pgen --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
 } else {
   exit_status = system(paste0("plink2 --bed ", opt$bfile, ".bed --fam ", opt$bfile, ".fam --bim ", opt$bfile, ".standard_snpid.bim --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
 }
@@ -150,8 +151,23 @@ bim_alpha_sorted <- bim_cleaned |>
   ) |>
   dplyr::select(CHR, snp_original, V3, BP, V5, V6)
 
-fwrite(
-  bim_alpha_sorted,
-  paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.bim"),
-  quote=F, na=NA, sep="\t", col.names = F)
+# Save
+if (is_pgen) {
+    pvar_alpha_sorted <- data.table(
+      `#CHROM` = bim_alpha_sorted$CHR,
+      POS = bim_alpha_sorted$BP,
+      ID = bim_alpha_sorted$snp_original,
+      REF = bim_alpha_sorted$V5,
+      ALT = bim_alpha_sorted$V6
+    )
 
+    fwrite(
+      pvar_alpha_sorted,
+      paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.pvar"),
+      quote = FALSE, na = NA, sep = "\t")
+} else {
+  fwrite(
+    bim_alpha_sorted,
+    paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.bim"),
+    quote=F, na=NA, sep="\t", col.names = F)
+}

--- a/bin/s01_alpha_sort_alleles_snpid.R
+++ b/bin/s01_alpha_sort_alleles_snpid.R
@@ -59,18 +59,20 @@ hg19ToHg38_liftover <- function(
 # Get arguments specified in the sbatch
 option_list <- list(
     make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
-    make_option("--file-type", default = NULL, help = "Input file type: plink1 or plink2"),
+    make_option("--bfile_type", default = NULL, help = "Input file type: plink1 or plink2"),
     make_option("--run_liftover", type = "logical", default=TRUE, help="Perform liftover to GRCh38?"),
     make_option("--grch", default=NULL, help="Genome reference build of GWAS sum stats")
 );
 opt_parser = OptionParser(option_list=option_list);
 opt = parse_args(opt_parser);
 
-# Detect input format
-is_pgen <- file.exists(paste0(opt$bfile, ".pgen"))
+bfile_type <- opt$bfile_type
 
 ## Read variant info
-if (is_pgen) {
+if(bfile_type=="plink1"){
+  bim <- fread(paste0(opt$bfile, ".bim"))
+  names(bim) <- c("CHR","snp_original","V3", "BP","V5","V6")
+} else if(bfile_type=="plink2"){
   # .pvar has header lines starting with ## and a #CHROM header line
   pvar <- fread(paste0(opt$bfile, ".pvar"), skip = "#CHROM")
   names(pvar)[1] <- "CHR"
@@ -82,9 +84,6 @@ if (is_pgen) {
     V5 = pvar$REF,
     V6 = pvar$ALT
   )
-} else {
-  bim <- fread(paste0(opt$bfile, ".bim"))
-  names(bim) <- c("CHR","snp_original","V3", "BP","V5","V6")
 }
 
 # Make a standardized snp id as CHR:BP:V5:V6 and save this as reference for downstream operations
@@ -93,19 +92,18 @@ bim <- bim |>
     snp_original = paste0(CHR, ":", BP, ":", V5, ":", V6)
   )
 
-if (is_pgen) {
-    pvar_standard <- data.table(
-        `#CHROM` = bim$CHR,
-        POS = bim$BP,
-        ID = bim$snp_original,
-        REF = bim$V5,
-        ALT = bim$V6
-    )
-    fwrite(pvar_standard, paste0(opt$bfile, ".standard_snpid.pvar"), quote = FALSE, na = NA, sep = "\t")
-} else {
-    fwrite(bim, paste0(opt$bfile, ".standard_snpid.bim"), quote = FALSE, na = NA, sep = "\t", col.names = FALSE)
+if(bfile_type=="plink1"){
+  fwrite(bim, paste0(opt$bfile, ".standard_snpid.bim"), quote = FALSE, na = NA, sep = "\t", col.names = FALSE)
+} else if(bfile_type=="plink2"){
+  pvar_standard <- data.table(
+    `#CHROM` = bim$CHR,
+    POS = bim$BP,
+    ID = bim$snp_original,
+    REF = bim$V5,
+    ALT = bim$V6
+  )
+  fwrite(pvar_standard, paste0(opt$bfile, ".standard_snpid.pvar"), quote = FALSE, na = NA, sep = "\t")
 }
-
 
 
 # Remove SNPs where SNP ID is duplicated since this can mess up liftOver and other operations downstream
@@ -130,10 +128,10 @@ extract_file <- paste0(opt$bfile, "_snps_to_extract.txt")
 fwrite(list(bim_cleaned |> dplyr::pull(snp_original) |> unique()), extract_file, col.names=F, quote=F)
 
 # Extract list of SNPs and output as bed/bim/fam or pgen/pvar/psam
-if (is_pgen) {
-  exit_status = system(paste0("plink2 --pgen ", opt$bfile, ".pgen --psam ", opt$bfile, ".psam --pvar ", opt$bfile, ".standard_snpid.pvar --extract ", extract_file, " --make-pgen --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
-} else {
+if(bfile_type=="plink1"){
   exit_status = system(paste0("plink2 --bed ", opt$bfile, ".bed --fam ", opt$bfile, ".fam --bim ", opt$bfile, ".standard_snpid.bim --extract ", extract_file, " --make-bed --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
+} else if(bfile_type=="plink2"){
+  exit_status = system(paste0("plink2 --pgen ", opt$bfile, ".pgen --psam ", opt$bfile, ".psam --pvar ", opt$bfile, ".standard_snpid.pvar --extract ", extract_file, " --make-pgen --out ", opt$bfile, ".GRCh38.alpha_sorted_alleles"))
 }
   
 # Raise an error if the external command fails
@@ -152,22 +150,21 @@ bim_alpha_sorted <- bim_cleaned |>
   dplyr::select(CHR, snp_original, V3, BP, V5, V6)
 
 # Save
-if (is_pgen) {
-    pvar_alpha_sorted <- data.table(
-      `#CHROM` = bim_alpha_sorted$CHR,
-      POS = bim_alpha_sorted$BP,
-      ID = bim_alpha_sorted$snp_original,
-      REF = bim_alpha_sorted$V5,
-      ALT = bim_alpha_sorted$V6
-    )
-
-    fwrite(
-      pvar_alpha_sorted,
-      paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.pvar"),
-      quote = FALSE, na = NA, sep = "\t")
-} else {
+if(bfile_type=="plink1"){
   fwrite(
     bim_alpha_sorted,
     paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.bim"),
     quote=F, na=NA, sep="\t", col.names = F)
+} else if(bfile_type=="plink2"){
+  pvar_alpha_sorted <- data.table(
+    `#CHROM` = bim_alpha_sorted$CHR,
+    POS = bim_alpha_sorted$BP,
+    ID = bim_alpha_sorted$snp_original,
+    REF = bim_alpha_sorted$V5,
+    ALT = bim_alpha_sorted$V6
+  )
+  fwrite(
+    pvar_alpha_sorted,
+    paste0(opt$bfile, ".GRCh38.alpha_sorted_alleles.pvar"),
+    quote = FALSE, na = NA, sep = "\t")
 }

--- a/bin/s02_sumstat_munging_and_aligning.R
+++ b/bin/s02_sumstat_munging_and_aligning.R
@@ -274,6 +274,15 @@ hg19ToHg38_liftover <- function(
 }
 
 
+### Auto-detect genotype format (pgen vs bed) for plink2 input flag
+get_plink2_input_flag <- function(prefix) {
+  if (file.exists(paste0(prefix, ".pgen"))) {
+    return(paste0("--pfile ", prefix))
+  } else {
+    return(paste0("--bfile ", prefix))
+  }
+}
+
 ### dataset.align function --------
 dataset.align <- function(dataset, bfile) {
   
@@ -306,7 +315,8 @@ dataset.align <- function(dataset, bfile) {
     message("Allele frequency not found in summary stat - Computing allele frequency from LD reference panel")
     ## Compute allele frequency from LD reference panel provided    
     random.number <- stringi::stri_rand_strings(n=1, length=20, pattern = "[A-Za-z0-9]")
-    exit_status = system(paste0("plink2 --bfile ", bfile, " --freq --make-just-bim --out ", random.number))
+    plink_input <- get_plink2_input_flag(bfile)
+    exit_status = system(paste0("plink2 ", plink_input, " --freq --make-just-bim --out ", random.number))
 
     # Raise an error if the external command fails
     if (exit_status != 0) {
@@ -523,7 +533,7 @@ option_list <- list(
   make_option("--type", default=NULL, help="Type of phenotype analysed - either 'quant' or 'cc' to denote quantitative or case-control"),
   make_option("--sdY", default=NULL, help="For a quantitative trait (type==quant), the population standard deviation of the trait. For quantitative traits, it can be a single value or a file containing per-phenotype `sdY` values. If not given, it will be estimated from beta and MAF"),
   make_option("--s", default=NULL, help="For a case control study (type==cc), the proportion of samples in dataset 1 that are cases"),
-  make_option("--bfile", default=NULL, help="Path and prefix name of custom/default LD bfiles (PLINK format .bed .bim .fam) - to compute effect allele frequency if missing"),
+  make_option("--bfile", default=NULL, help="Path and prefix name of custom/default LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar) - to compute effect allele frequency if missing"),
   make_option("--grch", default=NULL, help="Genome reference build of GWAS sum stats"),
   make_option("--run_liftover", default=FALSE, type="logical", help="Set true to run liftover"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),

--- a/bin/s02_sumstat_munging_and_aligning.R
+++ b/bin/s02_sumstat_munging_and_aligning.R
@@ -274,17 +274,8 @@ hg19ToHg38_liftover <- function(
 }
 
 
-### Auto-detect genotype format (pgen vs bed) for plink2 input flag
-get_plink2_input_flag <- function(prefix) {
-  if (file.exists(paste0(prefix, ".pgen"))) {
-    return(paste0("--pfile ", prefix))
-  } else {
-    return(paste0("--bfile ", prefix))
-  }
-}
-
 ### dataset.align function --------
-dataset.align <- function(dataset, bfile) {
+dataset.align <- function(dataset, bfile, bfile_type) {
   
   # Load munged dataset sumstat in .rds format (if necessary)
   if(is.character(dataset)){
@@ -315,8 +306,12 @@ dataset.align <- function(dataset, bfile) {
     message("Allele frequency not found in summary stat - Computing allele frequency from LD reference panel")
     ## Compute allele frequency from LD reference panel provided    
     random.number <- stringi::stri_rand_strings(n=1, length=20, pattern = "[A-Za-z0-9]")
-    plink_input <- get_plink2_input_flag(bfile)
-    exit_status = system(paste0("plink2 ", plink_input, " --freq --make-just-bim --out ", random.number))
+
+    if(bfile_type=="plink1"){
+      exit_status = system(paste0("plink2 --bfile ", bfile, " --freq --make-just-bim --out ", random.number))
+    } else if(bfile_type=="plink2"){
+      exit_status = system(paste0("plink2 --bfile ", pfile, " --freq --make-just-pvar --out ", random.number))
+    }
 
     # Raise an error if the external command fails
     if (exit_status != 0) {
@@ -330,9 +325,14 @@ dataset.align <- function(dataset, bfile) {
     #   read_delim(paste0(random.number,".afreq")) %>% dplyr::select(REF, ALT, ALT_FREQS)
     # ))
     
-    # Read .bim and select/rename columns
-    bim <- read_delim(paste0(random.number, ".bim"), col_names = FALSE)
-    bim <- bim[, c(1, 4)]
+    # Read .pvar/.bim and select/rename columns
+    if(bfile_type=="plink1"){
+      bim <- read_delim(paste0(random.number, ".bim"), col_names = FALSE)
+      bim <- bim[, c(1, 4)]
+    } else if(bfile_type=="plink2"){
+      bim <- read_delim(paste0(random.number, ".bim"), col_names = TRUE)
+      bim <- bim[, c(1, 2)]
+    }
     names(bim) <- c("CHR", "BP")
     
     # Read .afreq and select needed columns
@@ -534,6 +534,7 @@ option_list <- list(
   make_option("--sdY", default=NULL, help="For a quantitative trait (type==quant), the population standard deviation of the trait. For quantitative traits, it can be a single value or a file containing per-phenotype `sdY` values. If not given, it will be estimated from beta and MAF"),
   make_option("--s", default=NULL, help="For a case control study (type==cc), the proportion of samples in dataset 1 that are cases"),
   make_option("--bfile", default=NULL, help="Path and prefix name of custom/default LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar) - to compute effect allele frequency if missing"),
+  make_option("--bfile_type", default=NULL, help="Whether bfile is in plink2 pgen/pvar/psamj or plink1 bed/bim/fam format"),
   make_option("--grch", default=NULL, help="Genome reference build of GWAS sum stats"),
   make_option("--run_liftover", default=FALSE, type="logical", help="Set true to run liftover"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),
@@ -631,7 +632,7 @@ if(as.numeric(opt$grch)==37 & isTRUE(opt$run_liftover)){
 
 # Align GWAS sum stats
 message("Align alleles to BIM file")
-dataset_munged <- dataset.align(dataset_munged, bfile=opt$bfile)
+dataset_munged <- dataset.align(dataset_munged, bfile=opt$bfile, bfile_type=opt$bfile_type)
 
 # Now that we have clean, aligned data, do a final check for duplicated CHR BP and remove all duplicates
 # Report the number of duplicates removed

--- a/bin/s04_cojo_finemapping.R
+++ b/bin/s04_cojo_finemapping.R
@@ -12,7 +12,7 @@ option_list <- list(
   make_option("--dataset_aligned", default=NULL, help="GENOME-WIDE munged and aligned dataset file"),
   make_option("--p_thresh3", default=1e-04, help="Noise p-values threshold for COJO"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),
-  make_option("--bfile", default=NULL, help="Path and prefix name of custom LD bfiles (PLINK format .bed .bim .fam)"),
+  make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
   make_option("--skip_dentist", default=TRUE, help="Whether to skip the match of SNPs LD between GWAS sum stat and LD reference (performed by DENTIST), and consequent removal of mismatched SNPs"),
   make_option("--p_thresh4", default=1e-06, help="P-value significant threshold for redefining loci boundaries post-COJO"),  
   make_option("--hole", default=250000, help="Minimum pair-base distance between SNPs in different loci"),

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -12,7 +12,7 @@ option_list <- list(
   make_option("--dataset_aligned", default=NULL, help="GENOME-WIDE munged and aligned dataset file"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),
   make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
-  make_option("--bfile_type", default=NULL, help="Whether bfile is in plink2 pgen/pvar/psamj or plink1 bed/bim/fam format"),
+  make_option("--bfile_type", default=NULL, help="Whether bfile is in plink2 pgen/pvar/psam or plink1 bed/bim/fam format"),
   make_option("--skip_dentist", default=TRUE, help="Whether to skip the match of SNPs LD between GWAS sum stat and LD reference (performed by DENTIST), and consequent removal of mismatched SNPs"),
   make_option("--cs_thresh", default=0.99, help="Percentage of credible set"),
   make_option("--susie_max_iter", default=400, help="Maximum number of susie iterations"),

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -11,7 +11,7 @@ option_list <- list(
   make_option("--phenotype_id", default=NULL, help="Trait for which the locus boundaries have been identified - relevant in cases of molQTLs"),
   make_option("--dataset_aligned", default=NULL, help="GENOME-WIDE munged and aligned dataset file"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),
-  make_option("--bfile", default=NULL, help="Path and prefix name of custom LD bfiles (PLINK format .bed .bim .fam)"),
+  make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
   make_option("--skip_dentist", default=TRUE, help="Whether to skip the match of SNPs LD between GWAS sum stat and LD reference (performed by DENTIST), and consequent removal of mismatched SNPs"),
   make_option("--cs_thresh", default=0.99, help="Percentage of credible set"),
   make_option("--susie_max_iter", default=400, help="Maximum number of susie iterations"),

--- a/bin/s04_susie_finemapping.R
+++ b/bin/s04_susie_finemapping.R
@@ -12,6 +12,7 @@ option_list <- list(
   make_option("--dataset_aligned", default=NULL, help="GENOME-WIDE munged and aligned dataset file"),
   make_option("--maf", default=1e-04, help="MAF filter", metavar="character"),
   make_option("--bfile", default=NULL, help="Path and prefix name of custom LD genotype files (PLINK bed/bim/fam or pgen/psam/pvar)"),
+  make_option("--bfile_type", default=NULL, help="Whether bfile is in plink2 pgen/pvar/psamj or plink1 bed/bim/fam format"),
   make_option("--skip_dentist", default=TRUE, help="Whether to skip the match of SNPs LD between GWAS sum stat and LD reference (performed by DENTIST), and consequent removal of mismatched SNPs"),
   make_option("--cs_thresh", default=0.99, help="Percentage of credible set"),
   make_option("--susie_max_iter", default=400, help="Maximum number of susie iterations"),
@@ -78,6 +79,7 @@ susie_ld <- prep_susie_ld(
   locus_start=opt$start,
   locus_end=opt$end,
   bfile=opt$bfile,
+  bfile_type=opt$bfile_type,
   maf.thresh=opt$maf,
   random.number=random.number,
   skip_dentist=opt$skip_dentist

--- a/bin/validate_columns.py
+++ b/bin/validate_columns.py
@@ -49,10 +49,25 @@ def main():
         if not os.path.exists(gwas_path):
             print(f"The input GWAS {gwas_path} file was not found.", file=sys.stderr)
             return sys.exit(1)
-        # Check that the bfiles exist
-        if not all([os.path.exists(bfile_path + ".bim"), os.path.exists(bfile_path + ".bed"), os.path.exists(bfile_path + ".fam")]):
-            print(f"One of the bfiles {bfile_path} was not found.", file=sys.stderr)
+
+        # Check that bfiloes (either PLINK1 or PLINK2 format) exist
+        plink1_files = [bfile_path + ext for ext in [".bed", ".bim", ".fam"]]
+        plink2_files = [bfile_path + ext for ext in [".pgen", ".pvar", ".psam"]]
+
+        has_plink1 = all(os.path.exists(f) for f in plink1_files)
+        has_plink2 = all(os.path.exists(f) for f in plink2_files)
+
+        if has_plink2:
+            detected_bfile_type = "plink2"
+        elif has_plink1:
+            detected_bfile_type = "plink1"
+        else:
+            print(
+                f"Neither PLINK1 (.bed/.bim/.fam) nor PLINK2 (.pgen/.pvar/.psam) files were found for prefix {bfile_path}.",
+                file=sys.stderr
+            )
             return sys.exit(1)
+        print(f"Detected {detected_bfile_type} dataset for prefix {bfile_path}.")
 
         # Check that freq_lab and n_lab are not both missing
         if pd.isna(record['freq_lab']) and pd.isna(record['n_lab']):

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,6 +1,5 @@
 process {
-	conda = "/ssu/gassu/conda_envs/flanders_3.2"
-	// conda = "${projectDir}/pipeline_environment.yml"
+    conda = "${projectDir}/pipeline_environment.yml"
     container = "htgenomeanalysisunit/flanders:3.0.1"
 	
     // memory errors which should be retried. otherwise error out

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,9 @@ workflow {
 		INPUT_COLUMNS_VALIDATION.out.table_out
 			.splitCsv(header:true, sep:"\t")
 			.map{ row -> 
-				def bfile_dataset = params.is_test_profile ? file("${projectDir}/${row.bfile}.{bed,bim,fam}") : file("${row.bfile}.{bed,bim,fam}")
+				def bfile_bed = params.is_test_profile ? file("${projectDir}/${row.bfile}.{bed,bim,fam}") : file("${row.bfile}.{bed,bim,fam}")
+				def bfile_pgen = params.is_test_profile ? file("${projectDir}/${row.bfile}.{pgen,psam,pvar}") : file("${row.bfile}.{pgen,psam,pvar}")
+				def bfile_dataset = bfile_pgen.every { it.exists() } ? bfile_pgen : bfile_bed
 				tuple(
 					row.process_bfile,
 					row.bfile,

--- a/main.nf
+++ b/main.nf
@@ -48,33 +48,48 @@ workflow {
 		// Validate input file
 		INPUT_COLUMNS_VALIDATION(sumstats_input_file, base_dir)
 		
-		// Collect and process distinct bim datasets
+		// Collect and process distinct bfile datasets
 		INPUT_COLUMNS_VALIDATION.out.table_out
-			.splitCsv(header:true, sep:"\t")
-			.map{ row -> 
-				def bfile_bed = params.is_test_profile ? file("${projectDir}/${row.bfile}.{bed,bim,fam}") : file("${row.bfile}.{bed,bim,fam}")
-				def bfile_pgen = params.is_test_profile ? file("${projectDir}/${row.bfile}.{pgen,psam,pvar}") : file("${row.bfile}.{pgen,psam,pvar}")
-				def bfile_dataset = bfile_pgen.every { it.exists() } ? bfile_pgen : bfile_bed
-				tuple(
-					row.process_bfile,
-					row.bfile,
-					"${row.grch_bfile ? row.grch_bfile : row.grch}",
-					"${params.run_liftover ? "T" : "F"}",
-					bfile_dataset
-				)
-			}
-			.unique()
-			.branch { process_bfile_flag, bfile_id, grch_bfile, run_liftover, bfile_dataset ->
-				need_processing: process_bfile_flag in ["T", "t", "TRUE", "true", "True"] || (grch_bfile == "37" && run_liftover == "T") || process_bfile_flag == null
-				processed: true 
-			}
-			.set { bfile_datasets }
+    		.splitCsv(header:true, sep:"\t")
+    		.map { row ->
+        	    def prefix = params.is_test_profile ? "${projectDir}/${row.bfile}" : "${row.bfile}"
+        	    def plink1_files = [ file("${prefix}.bed"), file("${prefix}.bim"), file("${prefix}.fam") ]
+		    def plink2_files = [ file("${prefix}.pgen"), file("${prefix}.pvar"), file("${prefix}.psam") ]
+		    def has_plink1 = plink1_files.every { it.exists() }
+        	    def has_plink2 = plink2_files.every { it.exists() }
+
+		    if (!has_plink1 && !has_plink2) {
+		        throw new IllegalArgumentException(
+		        "Neither PLINK1 (.bed/.bim/.fam) nor PLINK2 (.pgen/.pvar/.psam) files found for prefix: ${prefix}"
+		    )
+        	}
+
+        	// Priority: PLINK2 > PLINK1
+        	def file_type = has_plink2 ? "plink2" : "plink1"
+        	def bfile_dataset = has_plink2 ? plink2_files : plink1_files
+
+        	tuple(
+	            row.process_bfile,
+	            row.bfile,
+	            "${row.grch_bfile ? row.grch_bfile : row.grch}",
+	            "${params.run_liftover ? 'T' : 'F'}",
+	            file_type,
+	            bfile_dataset
+		)
+	}
+    	.unique()
+    	.branch { process_bfile_flag, bfile_id, grch_bfile, run_liftover, file_type, bfile_dataset ->
+            need_processing: process_bfile_flag in ["T", "t", "TRUE", "true", "True"] || (grch_bfile == "37" && run_liftover == "T") || process_bfile_flag == null
+            processed: true
+    	}
+    	.set { bfile_datasets }
+
 
 		PROCESS_BFILE(bfile_datasets.need_processing, chain_file)
 
 		processed_bfile_datasets = bfile_datasets.processed
-			.map { process_bfile_flag, bfile_id, grch_bfile, run_liftover, bfile_dataset -> 
-				tuple(bfile_id, bfile_dataset)
+			.map { process_bfile_flag, bfile_id, grch_bfile, run_liftover, file_type, bfile_dataset -> 
+				tuple(bfile_id, file_type, bfile_dataset)
 			}
 			.mix(PROCESS_BFILE.out.processed_dataset)
 
@@ -96,8 +111,8 @@ workflow {
 			)
 		}
 		.combine(processed_bfile_datasets, by: 0)
-		.map { bfile_id, study_id, finemap_config, bfile_dataset ->
-			tuple(study_id, finemap_config, bfile_dataset)
+		.map { bfile_id, study_id, finemap_config, file_type, bfile_dataset ->
+			tuple(study_id, finemap_config, file_type, bfile_dataset)
 		}
 
 		// Define input channel for munging of GWAS sum stats
@@ -142,8 +157,8 @@ workflow {
 			)
 		}
 		.combine(processed_bfile_datasets, by: 0)
-		.map { bfile_id, study_id, munging_config, gwas_file, sdY_file, bfile_dataset ->
-			tuple(study_id, munging_config, gwas_file, sdY_file, bfile_dataset)
+		.map { bfile_id, study_id, munging_config, gwas_file, sdY_file, file_type, bfile_dataset ->
+			tuple(study_id, munging_config, gwas_file, sdY_file, file_type, bfile_dataset)
 		}
 
 		RUN_MUNGING(sumstas_input_ch, chain_file)

--- a/modules/local/mung_and_locus_breaker/main.nf
+++ b/modules/local/mung_and_locus_breaker/main.nf
@@ -9,7 +9,7 @@ process MUNG_AND_LOCUS_BREAKER {
   publishDir "${params.outdir}/results/gwas_and_loci_tables", mode: params.publish_dir_mode, pattern:"${meta_study_id.study_id}_loci.tsv"  
   
   input:
-    tuple val(meta_study_id), val(meta_parameters), path(gwas_input), path(sdY_file), path(bfile_dataset)
+    tuple val(meta_study_id), val(meta_parameters), path(gwas_input), path(sdY_file), val(file_type), path(bfile_dataset)
     path chain_file
 
   output:
@@ -42,6 +42,7 @@ process MUNG_AND_LOCUS_BREAKER {
         --sdY ${meta_parameters.sdY} \
         --s ${meta_parameters.s} \
         --bfile ${bfile_dataset[0].baseName} \
+        --bfile_type ${file_type} \
         --grch ${meta_parameters.grch} \
         --maf ${meta_parameters.maf} \
         --p_thresh1 ${meta_parameters.p_thresh1} \

--- a/modules/local/process_bfile/main.nf
+++ b/modules/local/process_bfile/main.nf
@@ -16,7 +16,7 @@ process PROCESS_BFILE {
 	"""
     s01_alpha_sort_alleles_snpid.R \
         --bfile ${bfile_dataset[0].baseName} \
-	--file-type ${file_type} \
+		--bfile_type ${file_type} \
         --grch ${genome_build} \
         --run_liftover ${run_liftover}
 	"""

--- a/modules/local/process_bfile/main.nf
+++ b/modules/local/process_bfile/main.nf
@@ -10,7 +10,7 @@ process PROCESS_BFILE {
     path chain_file
 
     output:
-    tuple val(bfile_id), val(file_type), path("${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.*"), emit: processed_dataset
+    tuple val(bfile_id), val(file_type), path("${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.{bed,bim,fam,pgen,pvar,psam}"), emit: processed_dataset
     
     script:
 	"""

--- a/modules/local/process_bfile/main.nf
+++ b/modules/local/process_bfile/main.nf
@@ -3,18 +3,20 @@ process PROCESS_BFILE {
     label "process_single"
 
     publishDir "${params.outdir}/processed_bfiles", mode: params.publish_dir_mode,  pattern: "${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.{bed,bim,fam}"
+    publishDir "${params.outdir}/processed_bfiles", mode: params.publish_dir_mode,  pattern: "${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.{pgen,pvar,psam}"
 
     input:
-    tuple val(bfile_process_flag), val(bfile_id), val(genome_build), val(run_liftover), path(bfile_dataset)
+    tuple val(bfile_process_flag), val(bfile_id), val(genome_build), val(run_liftover), val(file_type), path(bfile_dataset)
     path chain_file
 
     output:
-    tuple val(bfile_id), path("${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.{bed,bim,fam}"), emit: processed_dataset
+    tuple val(bfile_id), val(file_type), path("${bfile_dataset[0].baseName}.GRCh38.alpha_sorted_alleles.*"), emit: processed_dataset
     
     script:
 	"""
     s01_alpha_sort_alleles_snpid.R \
         --bfile ${bfile_dataset[0].baseName} \
+	--file-type ${file_type} \
         --grch ${genome_build} \
         --run_liftover ${run_liftover}
 	"""

--- a/modules/local/susie_finemapping/main.nf
+++ b/modules/local/susie_finemapping/main.nf
@@ -5,7 +5,7 @@ process SUSIE_FINEMAPPING {
   publishDir "${params.outdir}/results/finemap/", mode: params.publish_dir_mode, pattern:"*_susie_finemap.rds", enabled: params.publish_susie
 
   input:
-    tuple val(meta_study_id), val(meta_finemapping), path(bfile_dataset), val(meta_loci), path(gwas_final), path(gwas_final_index)
+    tuple val(meta_study_id), val(meta_finemapping), val(file_type), path(bfile_dataset), val(meta_loci), path(gwas_final), path(gwas_final_index)
     val outdir
   
   output:
@@ -30,6 +30,7 @@ process SUSIE_FINEMAPPING {
         --dataset_aligned ${gwas_final} \
         --maf ${meta_finemapping.maf} \
         --bfile ${bfile_dataset[0].baseName} \
+        --bfile_type ${file_type} \
         --skip_dentist ${meta_finemapping.skip_dentist} \
         --cs_thresh ${meta_finemapping.cs_thresh} \
         --susie_max_iter ${params.susie_max_iter}\


### PR DESCRIPTION
This PR addresses issue #104 by extending the pipeline to support PLINK2 format datasets (.pgen/.pvar/.psam) in addition to the existing PLINK1 (.bed/.bim/.fam) format. Employing dosages (when possible) should improve fine-mapping and allow the use of [SAFE-LD](https://github.com/davidebolo1993/safeld)-generated files.

The implementation is designed to:
- Accept both formats at input level, giving priority to the PLINK2 format if both are present
- Automatically detect dataset type
- Preserve the original input format throughout processing
- Maintain backward compatibility with existing workflows

## Key changes

### 1. Input validation (validate_columns.py)
- Updated validation logic to accept either:
  - PLINK1: .bed/.bim/.fam
  - PLINK2: .pgen/.pvar/.psam
- Validation now passes if at least one complete dataset exists
- Priority is implicitly given to PLINK2 when both formats are present

### 2. Dataset detection in main.nf
After INPUT_COLUMNS_VALIDATION, PLINK files are now assigned a `file_type` (`plink1` or `plink2`), which is passed downstream together with the PLINK files for:

-  PROCESS_BFILE
- MUNG_AND_LOCUS_BREAKER
- SUSIE_FINEMAPPING

Downstream channel structure has been updated accordingly.